### PR TITLE
Small Modifications and fixes

### DIFF
--- a/client/CampSetup.lua
+++ b/client/CampSetup.lua
@@ -72,6 +72,19 @@ function spawnItem(furntype, model)
                 PropCorrection(campfire)
                 campfirecreated = true
             end
+            while DoesEntityExist(campfire) do
+                Wait(5)
+                local x2,y2,z2 = table.unpack(GetEntityCoords(PlayerPedId()))
+                local dist = GetDistanceBetweenCoords(x, y, z, x2, y2, z2, true)
+                if dist < 2 then
+                    BccUtils.Misc.DrawText3D(x, y, z, Config.Language.RemoveFire)
+                    if IsControlJustReleased(0, 0x156F7119) then
+                        extinguishedCampfire()
+                    end
+                elseif dist > 200 then
+                    Wait(2000)
+                end
+            end
         elseif furntype == 'hitchingpost' then
             if hitchpostcreated then
                 VORPcore.NotifyRightTip(Config.Language.CantBuild, 4000)
@@ -215,5 +228,21 @@ AddEventHandler('bcc-camp:NearTownCheck', function()
     end
     if outoftown then
         MainTentmenu()
+    end
+end)
+----------------------------------- Delete camp fire -----------------------
+function extinguishedCampfire()
+    if campfirecreated then
+        local objectCoords = GetEntityCoords(campfire)
+        progressbarfunc(Config.SetupTime.FireSetupTime, Config.Language.FireSetup)
+        DeleteObject(campfire)
+        campfirecreated = false
+    end
+end
+
+----------------------- Delete camp when resource stops -----------------------------------
+AddEventHandler("onResourceStop", function(resource)
+    if resource == GetCurrentResourceName() then
+        delcamp()
     end
 end)

--- a/client/MenuSetup.lua
+++ b/client/MenuSetup.lua
@@ -150,7 +150,7 @@ function FurnMenu(furntype)
     if furntype == 'tent' then
         for k, v in pairs(Config.Furniture.Tent) do
             elements[elementindex] = {
-                label = v.hash,
+                label = v.name,
                 value = 'settent' .. tostring(elementindex),
                 desc = Config.Language.SetTent_desc,
                 info = v.hash
@@ -160,7 +160,7 @@ function FurnMenu(furntype)
     elseif furntype == 'bench' then
         for k, v in pairs(Config.Furniture.Benchs) do
             elements[elementindex] = {
-                label = v.hash,
+                label = v.name,
                 value = 'settent' .. tostring(elementindex),
                 desc = Config.Language.SetBench_desc,
                 info = v.hash
@@ -170,7 +170,7 @@ function FurnMenu(furntype)
     elseif furntype == 'hitchingpost' then
         for k, v in pairs(Config.Furniture.HitchingPost) do
             elements[elementindex] = {
-                label = v.hash,
+                label = v.name,
                 value = 'settent' .. tostring(elementindex),
                 desc = Config.Language.SetHitchPost_desc,
                 info = v.hash
@@ -180,7 +180,7 @@ function FurnMenu(furntype)
     elseif furntype == 'campfire' then
         for k, v in pairs(Config.Furniture.Campfires) do
             elements[elementindex] = {
-                label = v.hash,
+                label = v.name,
                 value = 'settent' .. tostring(elementindex),
                 desc = Config.Language.SetFire_desc,
                 info = v.hash
@@ -190,7 +190,7 @@ function FurnMenu(furntype)
     elseif furntype == 'storagechest' then
         for k, v in pairs(Config.Furniture.StorageChest) do
             elements[elementindex] = {
-                label = v.hash,
+                label = v.name,
                 value = 'settent' .. tostring(elementindex),
                 desc = Config.Language.SetStorageChest_desc,
                 info = v.hash

--- a/config.lua
+++ b/config.lua
@@ -49,29 +49,43 @@ Config.Furniture = {
     Campfires = { --campfire hash
         {
             hash = 'p_campfire01x', --model of fire
+            name = 'Large Campfire', -- Name for Menu
+        },
+        {
+            hash = 'p_campfire05x',
+            name = 'Small Campfire',
         },
     },
     Benchs = {
         {
             hash = 'p_bench_log03x',
+            name = 'Log Bench',
+        },
+        {
+            hash = 'p_ambchair02x',
+            name = 'Small Camp Chair',
         },
     },
     HitchingPost = {
         {
             hash = 'p_hitchingpost01x',
+            name = 'Double Hitching Post',
         },
     },
     Tent = {
         {
             hash = 'p_ambtentscrub01b',
+            name = 'Small Tent',
         },
         {
             hash = 'p_ambtentgrass01x',
+            name = 'Medium Tent',
         },
     },
     StorageChest = {
         {
             hash = 'p_chest01x',
+            name = 'Storage Chest',
         },
     },
 }
@@ -117,6 +131,7 @@ Config.Language = {
     StorageChestSetup = 'Placing Storage Chest! ',
     HitchingPostSetup = 'Setting up the hitching post! ',
     FastTravelPostSetup = 'Settin up the fast travel post! ',
+    RemoveFire = 'Press "BACKSPACE" to Remove The Camp Fire',
 
     --Camp Setup Translations
     CantBuild = 'You can not build here!',

--- a/server.lua
+++ b/server.lua
@@ -31,7 +31,9 @@ end)
 ----Removing camp item ---
 RegisterServerEvent('bcc-camp:RemoveCampItem', function()
   local _source = source
-  VORPInv.subItem(_source, Config.CampItem.CampItem, 1)
+  if Config.CampItem.RemoveItem then
+    VORPInv.subItem(_source, Config.CampItem.CampItem, 1)
+  end
 end)
 --This handles the version check
 BccUtils.Versioner.checkRelease(GetCurrentResourceName(), 'https://github.com/BryceCanyonCounty/bcc-camp')


### PR DESCRIPTION
- Added option to set object name to show in the camp menu, so it will be more userfriendly to players.
- The item that use to create the camp is removing from the inventory even if setup removeItem as false. Fixed this.
- All camps will be deleted when resource stops.
- Added option to remove the camp fire if player don't need it in the day time.