### PR TITLE
Give back Tent-Item after remove Camp

### DIFF
--- a/client/MenuSetup.lua
+++ b/client/MenuSetup.lua
@@ -89,7 +89,7 @@ function MainCampmenu(furntype)
 
     -- Button for Furniture Setup (Triggers the FurnitureTypeMenu)
     mainCampMenu:RegisterElement('button', {
-        label = "Furniture Setup",
+        label = _U('FurnitureSetup'),
         slot = "content",
         style = {},
     }, function()

--- a/config.lua
+++ b/config.lua
@@ -15,7 +15,8 @@ Config = {
     CampItem = {
         enabled = false,
         CampItem = 'tent',
-        RemoveItem = true
+        RemoveItem = true,
+	GiveBack = true,	-- Give back tent-item after remove camp
     }, --if enabled is true then you will need to use the CampItem to set tent make sure the item exists in your database if removeitem is true it will remove 1 of the item from the players inventory when they set camp
 
     -- Discord Webhooks

--- a/languages/de_lang.lua
+++ b/languages/de_lang.lua
@@ -22,12 +22,17 @@ Locales['de_lang'] = {
     TpDesc = 'Teleportiere zu ',
     FastTravelMenuName = 'Schnellreise ',
     SettingTentPbar = 'Baue das Zelt auf! ',
-    SettingBenchPbar = 'Baue die Bank auf! ',
-    FireSetup = 'Mache ein Lagerfeuer! ',
     StorageChestSetup = 'Platziere Lagerkiste! ',
-    HitchingPostSetup = 'Platziere Anbindepfosten! ',
     FastTravelPostSetup = 'Platziere Schnellreisepfosten! ',
     RemoveFire = 'Lagerfeuer Entfernen',
+    -- missing in CampSetup.lua
+    HitchingPostSetup = 'Platziere Anbindepfosten! ',
+    FireSetup = 'Mache ein Lagerfeuer! ',
+    SettingBenchPbar = 'Baue die Bank auf! ',
+    -- added because exists in CampSetup.lua
+    SettingItemPbar = "wird gebaut...",
+    -- added because missing in MenuSetup.lua
+    FurnitureSetup = "Möbel-Verwaltung",
 
     --Camp Setup Translations
     CantBuild = 'Du kannst hier nicht Bauen!',
@@ -53,19 +58,20 @@ Locales['de_lang'] = {
     furnitureMenu = 'Einrichtungs Menü',
     RemoveStorageChest = 'Entferne Lagerkiste',
     RemoveBench = 'Entferne Bank',
-    RemoveHitchPost = 'Entferne Anbindepfosten'
-    Remove = 'Remove',
-    Set = 'Set',
-    SelectModel = 'Select Model',
-    HitchingPost = 'Hitching Posts',
-    FastTravelPost = 'Fast Travel Posts',
-    Campfires = 'Camp Fires',
-    StorageChest = 'Storage Chests',
-    Tent = 'Tents',
-    Benchs = 'Benches',
-    Tables = 'Tables',
-    FurnitureTypes = 'Furniture Types',
-    FurnitureExists = 'Furniture Exists',
-    FurniturePlaced = 'Furniture Placed',
-    FurnitureCancel = 'Cancel Placement'
+    RemoveHitchPost = 'Entferne Anbindepfosten',
+    Remove = 'Entferne',
+    Set = 'Baue',
+    SelectModel = 'Wähle Modell',
+    HitchingPost = 'Anbindepfosten',
+    FastTravelPost = 'Schnellreise-Pfosten',
+    Campfires = 'Lagerfeuer',
+    StorageChest = 'Lagerkiste',
+    Tent = 'Zelt',
+    Benchs = 'Sitzgelegenheit',
+    Tables = 'Tisch',
+    FurnitureTypes = 'Möbel-Typ',
+    FurnitureExists = 'Möbel vorhanden',
+    FurniturePlaced = 'Möbel platziert',
+    FurnitureCancel = 'Platzierung abbrechen',
+
 }

--- a/languages/en_lang.lua
+++ b/languages/en_lang.lua
@@ -22,12 +22,17 @@ Locales['en_lang'] = {
     TpDesc = 'Teleport to ',
     FastTravelMenuName = 'Fast Travel ',
     SettingTentPbar = 'Pitching the tent! ',
-    SettingBenchPbar = 'Setting Up the Bench! ',
-    FireSetup = 'Starting a campfire! ',
     StorageChestSetup = 'Placing Storage Chest! ',
-    HitchingPostSetup = 'Setting up the hitching post! ',
     FastTravelPostSetup = 'Settin up the fast travel post! ',
     RemoveFire = 'Remove Camp Fire',
+    -- missing in CampSetup.lua
+    HitchingPostSetup = 'Setting up the hitching post! ',
+    FireSetup = 'Starting a campfire! ',
+    SettingBenchPbar = 'Setting Up the Bench! ',
+    -- added because exists in CampSetup.lua
+    SettingItemPbar = "is being built...",
+    -- added because missing in MenuSetup.lua
+    FurnitureSetup = "Furniture management",
 
     --Camp Setup Translations
     CantBuild = 'You can not build here!',

--- a/languages/ro_lang.lua
+++ b/languages/ro_lang.lua
@@ -22,12 +22,17 @@ Locales["ro_lang"] = {
     TpDesc = 'Teleportati-va la ',
     FastTravelMenuName = 'Calatorie Rapida',
     SettingTentPbar = 'Instalarea taberei!',
-    SettingBenchPbar = 'Configurarea bancii!',
-    FireSetup = 'Setarea unui foc de tabara!',
     StorageChestSetup = 'Plasarea Cufarului de Depozitare!',
-    HitchingPostSetup = 'Configurarea postului de legare!',
     FastTravelPostSetup = 'Configurarea postului de calatorie rapida!',
     RemoveFire = 'Elimina Focul de Tabara',
+    -- missing in CampSetup.lua
+    HitchingPostSetup = 'Configurarea postului de legare!',
+    FireSetup = 'Setarea unui foc de tabara!',
+    SettingBenchPbar = 'Configurarea bancii!',
+    -- added because exists in CampSetup.lua
+    SettingItemPbar = "se construieste...",
+    -- added because missing in MenuSetup.lua
+    FurnitureSetup = "Managementul mobilierului",
     
     -- Traduceri Configurare Tabara
     CantBuild = 'Nu poti construi aici!',

--- a/server/server.lua
+++ b/server/server.lua
@@ -361,7 +361,11 @@ AddEventHandler('bcc-camp:DeleteCamp', function()
     TriggerEvent('bcc-camp:loadCampData')
     -- Send a Discord notification for logging purposes
     Discord:sendMessage("**Camp Deleted**\nCharacter: " .. character.firstname .. " " .. character.lastname)
-    
+    if Config.CampItem.enabled then
+        if Config.CampItem.GiveBack then
+            exports.vorp_inventory:addItem(src, Config.CampItem.CampItem, 1)
+        end
+    end
 end)
 
 


### PR DESCRIPTION
some locals have been compressed.
However, this meant that there was no local for the general construction of an item.
I also put a missing translation reference in the menu and defined it in the locales.